### PR TITLE
ensure sync waves are used

### DIFF
--- a/ref-implementation/argo-workflows/manifests/dev/patches/deployment-argo-server.yaml
+++ b/ref-implementation/argo-workflows/manifests/dev/patches/deployment-argo-server.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: argo-server
   namespace: argo
+  annotations:
+    argocd.argoproj.io/sync-wave: "20"
 spec:
   template:
     spec:

--- a/ref-implementation/backstage/manifests/install.yaml
+++ b/ref-implementation/backstage/manifests/install.yaml
@@ -235,7 +235,7 @@ metadata:
   name: backstage
   namespace: backstage
   annotations:
-    argocd.argoproj.io/sync-wave: "10"
+    argocd.argoproj.io/sync-wave: "20"
 spec:
   replicas: 1
   selector:
@@ -296,6 +296,8 @@ metadata:
     app: postgresql
   name: postgresql
   namespace: backstage
+  annotations:
+    argocd.argoproj.io/sync-wave: "10"
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
This PR makes deployments and stateful sets wait for required secrets to be ready before getting synced.