### PR TITLE
fix: vclusters argo cluster secret labels

### DIFF
--- a/vcluster-multi-env/add-vclusters.sh
+++ b/vcluster-multi-env/add-vclusters.sh
@@ -28,8 +28,8 @@ metadata:
   namespace: argocd
   labels:
     argocd.argoproj.io/secret-type: cluster
-    cnoe.io/vclusterMultiEnv/clusterClass: "app-runtime"
-    cnoe.io/vclusterMultiEnv/clusterName: "${cluster_name}"
+    vcluster.cnoe.io/clusterClass: "app-runtime"
+    vcluster.cnoe.io/clusterName: "${cluster_name}"
 type: Opaque
 stringData:
   name: ${cluster_name}-vcluster


### PR DESCRIPTION
Kubernetes labels do not support more than 1 `/` in their name from what I understand:
> Labels are key/value pairs. Valid label keys have two segments: an optional prefix and name, separated by a slash (/). The name segment is required and must be 63 characters or less, beginning and ending with an alphanumeric character ([a-z0-9A-Z]) with dashes (-), underscores (_), dots (.), and alphanumerics between. The prefix is optional. If specified, the prefix must be a DNS subdomain: a series of DNS labels separated by dots (.), not longer than 253 characters in total, followed by a slash (/).

https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/

without this change I get the following error when runnign the `add-vclusters.sh` script:
```
* metadata.labels: Invalid value: "cnoe.io/vclusterMultiEnv/clusterName": a qualified name must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
* metadata.labels: Invalid value: "cnoe.io/vclusterMultiEnv/clusterClass": a qualified name must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
```